### PR TITLE
use bundled libsqlite3 on windows

### DIFF
--- a/db/Cargo.lock
+++ b/db/Cargo.lock
@@ -345,6 +345,7 @@ dependencies = [
  "html5ever",
  "indicatif",
  "kuchikiki",
+ "libsqlite3-sys",
  "log",
  "pulldown-cmark",
  "reqwest",
@@ -1138,6 +1139,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -29,3 +29,6 @@ tokio = { version = "1.40", features = ["full"] }
 tokio-util = "0.7"
 toml = "0.8"
 urlencoding = "2.1"
+
+[target.'cfg(windows)'.dependencies]
+libsqlite3-sys = { version = "0.30.1", features = ["bundled"] }


### PR DESCRIPTION
diesel mentions that you can do this and it’s the easiest way to do everything on windows. it might also be easier on macOS but i can’t conveniently check if macOS ships with libsqlite3 out of the box although i suspect it does not