### PR TITLE
cdl2: Add flag to load new posts since last run.

### DIFF
--- a/db/config.example.toml
+++ b/db/config.example.toml
@@ -31,6 +31,10 @@ load_dashboard = false
 # load all liked posts for the currently active page
 load_likes = false
 
+# load new posts for all projects previously saved in full
+# (does not affect liked posts or bookmarked tags)
+load_new_posts = false
+
 # when loading the dashboard: ignore these particular projects
 skip_follows = [
     'example-handle',

--- a/db/src/main.rs
+++ b/db/src/main.rs
@@ -55,6 +55,8 @@ pub struct Config {
     #[serde(default)]
     pub skip_follows: Vec<String>,
     #[serde(default)]
+    pub load_new_posts: bool,
+    #[serde(default)]
     pub load_comments: bool,
     #[serde(default)]
     pub load_post_resources: bool,


### PR DESCRIPTION
Hi there — I made this change so I could update my own archive, and figured I may as well make a pull request in case it's helpful.  No worries if you want to ignore this, hahah.

> Includes all pages that have previously been fully saved, minus those excluded by skip_follows.
> 
> Unfortunately, this does not include liked posts, as those are ordered by time posted and not time liked, so newly-liked posts might appear anywhere in the list.
> 
> It also doesn't affect bookmarked tags; I think that should be fine, since I think those were only added to cohost-dl after Cohost had gone read-only anyway?